### PR TITLE
Specify $arg_separator in http_build_query()

### DIFF
--- a/wepay.php
+++ b/wepay.php
@@ -80,7 +80,7 @@ class WePay {
 			'state'        => empty($options['state'])      ? '' : $options['state'],
 			'user_name'    => empty($options['user_name'])  ? '' : $options['user_name'],
 			'user_email'   => empty($options['user_email']) ? '' : $options['user_email'],
-		));
+		), '', '&');
 		return $uri;
 	}
 


### PR DESCRIPTION
It defaults to arg_separator.output which may not be understood by WePay servers.

This parameter is available since PHP 5.1.2, I'm not sure what's the minimum PHP version supported by the SDK.
