### PR TITLE
Disallow setting custom HTTP headers

### DIFF
--- a/wepay.php
+++ b/wepay.php
@@ -157,6 +157,9 @@ class WePay {
 		if ($token && !is_string($token)) {
 			throw new InvalidArgumentException('$token must be a string, ' . gettype($token) . ' provided');
 		}
+		if ($token && strpos($token, "\n") !== false) {
+			throw new InvalidArgumentException('$token must not contain a newline');
+		}
 		$this->token = $token;
 	}
 


### PR DESCRIPTION
By setting $token to "real_token\nEvil-Header: booom", it was possible to send a custom HTTP header to WePay servers. It's not a big deal and the servers must handle that correctly but API shouldn't support a hack like this.