### PR TITLE
Require _shared.php from local dir

### DIFF
--- a/demoapp/login.php
+++ b/demoapp/login.php
@@ -1,5 +1,5 @@
 <?php
-require '_shared.php';
+require './_shared.php';
 
 // ** YOU MUST CHANGE THIS FOR THE SAMPLE APP TO WORK **
 $redirect_uri = 'http://YOUR SERVER NAME/login.php';


### PR DESCRIPTION
If the file with the same name exists in include_path directory then it was used instead.
