### PR TITLE
Escape external data in demo apps

### DIFF
--- a/demoapp/_shared.php
+++ b/demoapp/_shared.php
@@ -1,4 +1,5 @@
 <?php
 require '../wepay.php';
 Wepay::useStaging('YOUR CLIENT ID', 'YOUR CLIENT SECRET');
+header('Content-Type: text/html; charset=utf-8');
 session_start();

--- a/demoapp/accountlist.php
+++ b/demoapp/accountlist.php
@@ -10,7 +10,10 @@ try {
 	$wepay = new WePay($_SESSION['wepay_access_token']);
 	$accounts = $wepay->request('account/find');
 	foreach ($accounts as $account) {
-		echo "<a href=\"$account->account_uri\">$account->name</a>: $account->description <br />";
+		echo "<a href=\"" . htmlspecialchars($account->account_uri) . "\">";
+		echo htmlspecialchars($account->name);
+		echo "</a>: ";
+		echo htmlspecialchars($account->description) . "<br />";
 	}
 }
 catch (WePayException $e) {

--- a/demoapp/login.php
+++ b/demoapp/login.php
@@ -16,7 +16,7 @@ if (!empty($_SESSION['wepay_access_token'])) {
 // like a domain mismatch on your redirect_uri
 if (!empty($_GET['error'])) {
 	echo 'Error during user authentication: ';
-	echo htmlentities($_GET['error_description']);
+	echo htmlspecialchars($_GET['error_description']);
 	exit;
 }
 

--- a/demoapp/openaccount.php
+++ b/demoapp/openaccount.php
@@ -8,16 +8,17 @@ require './_shared.php';
 <?php
 if ($_SERVER['REQUEST_METHOD'] == 'POST') {
 	if (isset($_POST['account_name']) && isset($_POST['account_description'])) {
-		// WePay sanitizes its own data, but displaying raw POST data on your own site is a XSS security hole.
-		$name = htmlentities($_POST['account_name']);
-		$desc = htmlentities($_POST['account_description']);
 		try {
 			$wepay = new WePay($_SESSION['wepay_access_token']);
 			$account = $wepay->request('account/create', array(
-				'name' => $name,
-				'description' => $desc,
+				'name' => $_POST['account_name'],
+				'description' => $_POST['account_description'],
 			));
-			echo "Created account $name for '$desc'! View on WePay at <a href=\"$account->account_uri\">$account->account_uri</a>. See all of your accounts <a href=\"accountlist.php\">here</a>.";
+			// WePay sanitizes its own data, but displaying raw POST data on your own site is a XSS security hole.
+			$name = htmlspecialchars($_POST['account_name']);
+			$desc = htmlspecialchars($_POST['account_description']);
+			$account_uri = htmlspecialchars($account->account_uri);
+			echo "Created account $name for '$desc'! View on WePay at <a href=\"$account_uri\">$account_uri</a>. See all of your accounts <a href=\"accountlist.php\">here</a>.";
 		}
 		catch (WePayException $e) {
 			// Something went wrong - normally you would log

--- a/demoapp/user.php
+++ b/demoapp/user.php
@@ -11,7 +11,8 @@ try {
 	$user = $wepay->request('user');
 	echo '<dl>';
 	foreach ($user as $key => $value) {
-		echo "<dt>$key</dt><dd>$value</dd>";
+		echo "<dt>" . htmlspecialchars($key) . "</dt>";
+		echo "<dd>" . htmlspecialchars($value) . "</dd>";
 	}
 	echo '</dl>';
 }

--- a/iframe_demoapp/checkout.php
+++ b/iframe_demoapp/checkout.php
@@ -52,7 +52,7 @@ try {
 		<p>The user will checkout here:</p>
 		
 		<?php if (isset($error)): ?>
-			<h2 style="color:red">ERROR: <?php echo $error ?></h2>
+			<h2 style="color:red">ERROR: <?php echo htmlspecialchars($error); ?></h2>
 		<?php else: ?>
 			<div id="checkout_div"></div>
 		

--- a/iframe_demoapp/list_accounts.php
+++ b/iframe_demoapp/list_accounts.php
@@ -45,7 +45,7 @@ try {
 		<p>The following is a list of all accounts that this user owns</p>
 		
 		<?php if (isset($error)): ?>
-			<h2 style="color:red">ERROR: <?php echo $error ?></h2>
+			<h2 style="color:red">ERROR: <?php echo htmlspecialchars($error); ?></h2>
 		<?php elseif (empty($accounts)) : ?>
 			<h2>You do not have any accounts. Go to <a href="https://stage.wepay.com.com">https://stage.wepay.com</a> to open an account.<h2>
 		<?php else: ?>
@@ -60,9 +60,9 @@ try {
 				<tbody>
 				<?php foreach ($accounts as $a): ?>
 					<tr>
-						<td><?php echo $a->account_id ?></td>
-						<td><?php echo $a->name ?></td>
-						<td><?php echo $a->description ?></td>
+						<td><?php echo htmlspecialchars($a->account_id); ?></td>
+						<td><?php echo htmlspecialchars($a->name); ?></td>
+						<td><?php echo htmlspecialchars($a->description); ?></td>
 					</tr>
 				<?php endforeach;?>
 				</tbody>


### PR DESCRIPTION
It seems that WePay sanitizes its data in some way. But all external data should be escaped anyway in a good application written defensively. Moreover, WePay returns & as & so we need to escape at least that to get a valid XHTML.

A PHP application must specify its output encoding to allow escaping functions work properly so I've done also that. If Unicode character set is used then htmlspecialchars() escapes all we need and htmlentities() is not required as it escapes even characters that don't need any escaping.