### PR TITLE
Don't issue a warning if an API response has no "error_code"

### DIFF
--- a/wepay.php
+++ b/wepay.php
@@ -213,17 +213,23 @@ class WePay {
 			throw new Exception('cURL error while making API call to WePay: ' . curl_error(self::$ch), $errno);
 		}
 		$result = json_decode($raw);
+
+		$error_code = null;
+		if (isset($result->error_code)) {
+		  $error_code = $result->error_code;
+		}
+
 		$httpCode = curl_getinfo(self::$ch, CURLINFO_HTTP_CODE);
 		if ($httpCode >= 400) {
 			if ($httpCode >= 500) {
-				throw new WePayServerException($result->error_description, $httpCode, $result, $result->error_code);
+				throw new WePayServerException($result->error_description, $httpCode, $result, $error_code);
 			}
 			switch ($result->error) {
 				case 'invalid_request':
-					throw new WePayRequestException($result->error_description, $httpCode, $result, $result->error_code);
+					throw new WePayRequestException($result->error_description, $httpCode, $result, $error_code);
 				case 'access_denied':
 				default:
-					throw new WePayPermissionException($result->error_description, $httpCode, $result, $result->error_code);
+					throw new WePayPermissionException($result->error_description, $httpCode, $result, $error_code);
 			}
 		}
 		


### PR DESCRIPTION
In certain unusual situations, the API may produce a JSON response that has no
"error_code" key. In this case, the client currently tries to access it and
issues a warning ("PHP Notice:  Undefined property ...") depending on
configuration.

Instead, test that "error_code" exists before accessing it.

You can reproduce this issue with this test script:

``` php
<?php

error_reporting(E_ALL | E_NOTICE);
require_once 'wepay.php';

/*

When making a call like this, WePay returns this response:

  {
    "error":
      "invalid_request",
    "error_description":
      "You are trying to use an access_token from production on stage"
  }

This response has no "error_code", which causes the API client to issue a
warning.

*/

WePay::useStaging('invalid', 'invalid');
$wepay = new WePay('PRODUCTION_invalid');

try {
  $wepay->request(
    'checkout/create',
    array(
      'account_id'        => 'any string',
      'short_description' => 'any string',
      'type'              => 'any string',
      'amount'            => '1.00',
    ));
} catch (Exception $ex) {
  // Ignore.
}
```

The expected behavior is no output; the actual behavior is that a warning is issued. After this patch, the warning does not occur.

This issue seems to be relatively specific to the "...production on stage" error; other responses consistently seem to have error codes. So an alternative solution would be to adjust the API to return an "error_code" in this case.
