### PR TITLE
Added risk header support

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,22 @@ please see [our documentation](https://www.wepay.com/developer/reference). For s
 `demoapp` directory and check the README. Dropping the entire directory in a web-accessible location and adding your 
 API keys should allow you to be up and running in just a few seconds.
 
+### Risk Headers ###
+
+You can supply WePay with risk-related information on every API call by passing the WePay-Risk-Token and Client-IP values to the `request` function:
+
+```
+$checkout = $wepay->request('/checkout/create', array(
+                'account_id' => 1723052,
+                'amount' => 50,
+                'currency': 'USD',
+                'short_description': 'Selling 42 Pens',
+                'type': 'goods'
+            ), '123e4567-e89b-12d3-a456-426655440000', '100.166.99.123');
+```
+
+Detailed information regarding the Risk Headers can be found at the [WePay API Documentation](https://developer.wepay.com/reference/risk_headers).
+
 Security
 --------
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ API keys should allow you to be up and running in just a few seconds.
 You can supply WePay with risk-related information on every API call by passing the WePay-Risk-Token and Client-IP values to the `request` function:
 
 ```
-$checkout = $wepay->request('/checkout/create', array(
+$checkout = $wepay->request('checkout/create', array(
                 'account_id' => 1723052,
                 'amount' => 50,
                 'currency': 'USD',

--- a/wepay.php
+++ b/wepay.php
@@ -26,7 +26,7 @@ class WePay
     /**
      * Version number - sent in user agent string
      */
-    const VERSION = '0.3.0';
+    const VERSION = '0.3.1';
 
     /**
      * Scope fields

--- a/wepay.php
+++ b/wepay.php
@@ -316,18 +316,28 @@ class WePay
 
     /**
      * Make API calls against authenticated user
-     * @param  string         $endpoint - API call to make (ex. 'user', 'account/find')
-     * @param  array          $values   - Associative array of values to send in API call
+     * @param  string         $endpoint     - API call to make (ex. 'user', 'account/find')
+     * @param  array          $values       - Associative array of values to send in API call
+     * @param  string         $risk_token   - WePay-supplied risk token associated with this API call
+     * @param  string         $client_ip    - Client's IP address associated with this API call
      * @return StdClass
      * @throws WePayException on failure
      * @throws Exception      on catastrophic failure (non-WePay-specific cURL errors)
      */
-    public function request($endpoint, array $values = array())
+    public function request($endpoint, array $values = array(), $risk_token = null, $client_ip = null)
     {
         $headers = array();
 
         if ($this->token) { // if we have an access_token, add it to the Authorization header
             $headers[] = "Authorization: Bearer $this->token";
+        }
+
+        if ($risk_token) { // if we have a risk_token, add it to the WePay-Risk-Token header
+            $headers[] = "WePay-Risk-Token: " . $risk_token;
+        }
+
+        if ($client_ip) { // if we have a client_ip, add it to the Client-IP header
+            $headers[] = "Client-IP: " . $client_ip;
         }
 
         $result = self::make_request($endpoint, $values, $headers);


### PR DESCRIPTION
WePay-Risk-Token and Client-IP are now available headers on all API calls (see: https://developer.wepay.com/reference/risk_headers). This PR adds support for these optional headers and updates the README.