### PR TITLE
Resolve PHP Deprecation Notice in PHP 8.2: Creation of dynamic property

### DIFF
--- a/wepay.php
+++ b/wepay.php
@@ -363,6 +363,8 @@ class WePay
  */
 class WePayException extends Exception
 {
+    public $response = false;
+    
     public function __construct($description = '', $http_code = FALSE, $response = FALSE, $code = 0, $previous = NULL)
     {
         $this->response = $response;


### PR DESCRIPTION
In PHP 8.2, the creation of dynamic properties will emit a deprecation notice. For more information see https://php.watch/versions/8.2/dynamic-properties-deprecated

By default the existing behavior was a public variable so adding this public declaration is in line with existing functionality.

**WePay PHP SDK Version**
v0.3.1

**Behavior before this change**
Deprecated: Creation of dynamic property WePayRequestException::$response is deprecated in /vendor/wepay/php-sdk/wepay.php on line 370

**Behavior after this change**
_No deprecation notice_

**Additional Notes**
I don't see this variable used anywhere but since it was dynamically created, it was created as a public variable so other developers could have technically used this in their projects. Removing line 370 would also resolve the deprecation notice but it would break anyone currently referencing this variable. This is why I selected to use a public variable to be consistent with existing functionality.